### PR TITLE
Update binkp.h

### DIFF
--- a/src/binkp.h
+++ b/src/binkp.h
@@ -43,7 +43,7 @@
 
 
 /* messages */
-enum {
+static enum {
     BPM_NONE = 99,		/* No available data */
     BPM_DATA = 98,		/* Binary data */
     BPM_NUL = 0,		/* Site information */


### PR DESCRIPTION
Fixed compilation fail caused by duplicate definition of bp_msg.